### PR TITLE
Added a fix for confirming the rails 5 destructive action check

### DIFF
--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -4,7 +4,10 @@ namespace :deploy do
       set :rails_db_options, [ ENV['VERSION'] ? "VERSION=#{ENV['VERSION']}" : nil,
                                ENV['VERBOSE'] ? "VERBOSE=#{ENV['VERBOSE']}" : nil,
                                ENV['SCOPE']   ? "SCOPE=#{ENV['SCOPE']}"     : nil,
-                               ENV['STEP']    ? "STEP=#{ENV['STEP']}"       : nil ].compact
+                               ENV['STEP']    ? "STEP=#{ENV['STEP']}"       : nil,
+                               ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK'] ?
+                                   "DISABLE_DATABASE_ENVIRONMENT_CHECK=#{ENV['DISABLE_DATABASE_ENVIRONMENT_CHECK']}" :
+                                   nil].compact
     end
 
     { abort_if_pending_migrations: '',


### PR DESCRIPTION
Rails 5 added a confirmation step when performing destructive database actions (like db:drop or db:migrate:reset).

This simple fix allows the required environment variable to propagate through to the target, to allow users to perform destructive actions on rails 5 apps.